### PR TITLE
Fix resume build command

### DIFF
--- a/resume/DEVELOPMENT.md
+++ b/resume/DEVELOPMENT.md
@@ -9,7 +9,8 @@
 I have a built image of the [Dockerfile](./Dockerfile) at [dolfolife/latex](https://hub.docker.com/r/dolfolife/latex) that you can use at any time like
 
 ```sh
-docker run --rm -i --user="$(id -u):$(id -g)" --net=none -v "[FOLDER_WITH_THE_TEX_FILE]":/resume dolfolife/latex:0.0.2 /bin/sh -c "pdflatex file.tex & pdflatex file.tex"
+docker run --rm -i --user="$(id -u):$(id -g)" --net=none -v "[FOLDER_WITH_THE_TEX_FILE]":/resume \
+  dolfolife/latex:0.0.2 /bin/sh -c "pdflatex file.tex && pdflatex file.tex"
 ```
 
 _note: the dependencies I install in the Dockerfile layers are specific for my needs of my resume. If you need more dependencies you can extend or copy the Dockerfile to add those._


### PR DESCRIPTION
## Summary
- fix background operator usage for resume build command

## Testing
- `pdflatex --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ed3e221083339b12bcbefb69fc1c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Docker run command example for improved reliability and readability. The second `pdflatex` command now runs only after the first completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->