### PR TITLE
Fix typos and workflow linting

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Get version
       id: version
       run: echo "version=$(cat resume/VERSION)" >> $GITHUB_ENV
+
+    - name: Lint Dockerfile
+      uses: hadolint/hadolint-action@v1.5.0
+      with:
+        dockerfile: resume/Dockerfile
+        failure-threshold: warning
     - name: Build the Docker image
       uses: docker/build-push-action@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 *.out
 *.DS_Store
 *.pdf
-*.vscode
+.vscode/

--- a/resume/resume.tex
+++ b/resume/resume.tex
@@ -123,7 +123,7 @@
 
 \cvevent{Previous Software Engineering positions}{Sears Holdings, Enova, and others}{2009 -- 2016}{IL, US}
 \begin{itemize}
-    \item Designed, archited, and developed data-intensive products for small teams to big organizations.
+    \item Designed, architected, and developed data-intensive products for small teams to big organizations.
 \end{itemize}
 
 \medskip

--- a/user-manual/README.md
+++ b/user-manual/README.md
@@ -24,7 +24,7 @@ Thank you for taking the time to read my user manual. The purpose of this guide 
 
 - I use Slack to keep in touch with my team, colleagues, and friends. You can find me on Kubernetes, Cloud Foundry, or Knative Slack by mentioning @dolfo.
 
-## How I best received feedback
+## How I best receive feedback
 
 - I appreciate specific and actionable feedback that helps me improve my work.
 - I prefer written feedback followed by a conversation, especially if there are any topics that I might not fully understand.


### PR DESCRIPTION
## Summary
- fix `.gitignore` rule for VSCode
- correct "archited" typo in resume
- clarify feedback heading in user manual
- add Dockerfile lint step to workflow

## Testing
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_6847ed3e1d3c8333bba37d063127809a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to include Dockerfile linting with warnings reported but not failing the build.
  - Improved .gitignore rule to correctly exclude the .vscode directory.

- **Documentation**
  - Fixed a typo in the resume, correcting "archited" to "architected."
  - Updated a heading in the user manual for grammatical accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->